### PR TITLE
Fix Windows issues

### DIFF
--- a/etl/ReadMe.md
+++ b/etl/ReadMe.md
@@ -1,6 +1,6 @@
 ### Introduction
 
-With the scripts provided, data can be extracted from MS Excel files and loaded into PostgreSQL. All scripts are either R scripts or SQL scripts. The R scripts are primarily used to convert data from MS Excel format to CSV format (with little or no transformation applied), and to load *analysis*, core and *metadata* directly into staging tables (database schema *import*). The SQL scripts are used to populate the codelist tables (schema *codelists*), and to transform data and load them into the final tables in schemas *core*, *analysis* and *metadata*. Errors and data inconsistencies are logged to eight tables in schema *import\_log*.
+With the scripts provided, data can be extracted from MS Excel files and loaded into PostgreSQL. All scripts are either R scripts or SQL scripts. The R scripts are primarily used to convert data from MS Excel format to CSV format (with little or no transformation applied), and to load *analysis*, core and *metadata* directly into staging tables (database schema *import*). The SQL scripts are used to populate the codelist tables (schema *codelists*), and to transform data and load them into the final tables in schemas *core*, *analysis* and *metadata*. Errors and data inconsistencies are logged to eight tables in schema *import\_log*. To avoid encoding issues on Windows set the environment variable *PGCLIENTENCODING* to *UTF8* before running the scripts.
 
 ### Usage
 

--- a/etl/r/1_analysis_core_and_metadata2csv_and_pg.R
+++ b/etl/r/1_analysis_core_and_metadata2csv_and_pg.R
@@ -1,12 +1,12 @@
 library(openxlsx)
-library(RPostgreSQL)
+library(RPostgres)
 library(argparse)
+library(readr)
 
 # DB connection
 createDbConn <- function(database, host, port, user, password) {
 
-  drv <- dbDriver("PostgreSQL")
-  con <- dbConnect(drv, dbname=database, host=host, port=port, user=user, password=password)
+  con <- dbConnect(RPostgres::Postgres(), dbname=database, host=host, port=port, user=user, password=password, sslmode='prefer')
   dbGetQuery(con, "SET SEARCH_PATH TO import, public")  
   return (con)
 }
@@ -23,7 +23,7 @@ xlsx2df <- function(dataDir, xlsFileName, sheetName = NULL) {
 
 df2csv <- function(dataDir, subDir, csvFileName, df) {
   
-  write.table(df, file=paste0(dataDir, subDir, csvFileName), sep="\t", row.names = FALSE, fileEncoding='utf8', na="", quote=FALSE)
+  write_delim(df, file=paste0(dataDir, subDir, csvFileName), delim="\t", na="")
   return (invisible(NULL))
 }
 

--- a/etl/r/2_codelist_data2csv.R
+++ b/etl/r/2_codelist_data2csv.R
@@ -1,6 +1,7 @@
 library(openxlsx)
 library(stringr)
 library(argparse)
+library(readr)
 
 xlsx2df <- function(dataDir, xlsFileName, sheetName = NULL) {
   
@@ -18,7 +19,7 @@ df2csv <- function(dataDir, csvFileName, df) {
   if (!dir.exists(file.path(dataDir, subDir))) {
     dir.create(file.path(dataDir, subDir))
   }
-  write.table(df, file=paste0(dataDir, subDir, csvFileName), sep="\t", row.names = FALSE, fileEncoding='utf8', na="", quote=FALSE)
+  write_delim(df, file=paste0(dataDir, subDir, csvFileName), delim="\t", na="")
   return (invisible(NULL))
 }
 

--- a/etl/sql/1_empty_tables.sql
+++ b/etl/sql/1_empty_tables.sql
@@ -1,3 +1,5 @@
+BEGIN;
+
 SET SEARCH_PATH TO core, metadata, codelists, analysis, import_log, public;
 
 DELETE FROM log_duplicate_analysis_ids;
@@ -33,6 +35,7 @@ DELETE FROM co_sample;
 DELETE FROM co_organism_captured;
 DELETE FROM co_project_sampling_organism;
 DELETE FROM co_sampling_organism;
+DELETE FROM co_well_sampling_environment;
 DELETE FROM co_sampling_environment;
 
 DELETE FROM md_ddd;
@@ -89,3 +92,5 @@ DELETE FROM cl_tissue;
 DELETE FROM cl_vessel;
 DELETE FROM cl_vessel_storage;
 DELETE FROM cl_vessel_well;
+
+COMMIT;


### PR DESCRIPTION
I am using two different R libraries now to prevent issues on Windows. To avoid encoding issues on Windows (as with the mikro character) set the environment variable _PGCLIENTENCODING_ to _UTF8_ before running any of the scripts. 